### PR TITLE
Add Learn page with video/document viewer and study features

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -23,6 +23,7 @@ import Chatbot from "./pages/Chatbot";
 import Progress from "./pages/Progress";
 import Settings from "./pages/Settings";
 import Lesson from "./pages/Lesson";
+import Learn from "./pages/Learn";
 import Exercise from "./pages/Exercise";
 import ExerciseResults from "./pages/ExerciseResults";
 import Quiz from "./pages/Quiz";
@@ -93,6 +94,7 @@ function AppRoutes() {
         <Route path="/chatbot" element={<Chatbot />} />
         <Route path="/progress" element={<Progress />} />
         <Route path="/settings" element={<Settings />} />
+        <Route path="/learn" element={<Learn />} />
         <Route path="/lesson/:id" element={<Lesson />} />
         <Route path="/lesson/:lessonId/exercise/:id" element={<Exercise />} />
         <Route

--- a/client/components/DashboardHome.tsx
+++ b/client/components/DashboardHome.tsx
@@ -170,7 +170,7 @@ const currentCourses = [
     thumbnail: "/placeholder.svg",
     category: "Anh",
     level: "Trung bình",
-    emoji: "🗣️",
+    emoji: "🗣���",
   },
 ];
 
@@ -228,7 +228,7 @@ export function DashboardHome() {
             <CardTitle className="text-sm font-medium">
               ⏰ Thời gian học
             </CardTitle>
-            <div className="text-2xl">���</div>
+            <div className="text-2xl">📖</div>
           </CardHeader>
           <CardContent>
             <div className="text-3xl font-bold text-primary">45h</div>
@@ -405,7 +405,7 @@ export function DashboardHome() {
                     </div>
 
                     {/* Action Button */}
-                    <Button className="w-full bg-gradient-to-r from-primary to-accent hover:from-primary/80 hover:to-accent/80 text-white font-medium rounded-xl transition-all duration-300 hover:scale-105">
+                    <Button onClick={() => navigate("/study-plan")} className="w-full bg-gradient-to-r from-primary to-accent hover:from-primary/80 hover:to-accent/80 text-white font-medium rounded-xl transition-all duration-300 hover:scale-105">
                       <Play className="h-4 w-4 mr-2" />
                       {course.progress === 0
                         ? "🚀 Bắt đầu học!"

--- a/client/components/DashboardHome.tsx
+++ b/client/components/DashboardHome.tsx
@@ -174,7 +174,10 @@ const currentCourses = [
   },
 ];
 
+import { useNavigate } from "react-router-dom";
+
 export function DashboardHome() {
+  const navigate = useNavigate();
   return (
     <div className="flex-1 space-y-6 p-6 bg-gradient-to-br from-background via-accent/5 to-primary/5">
       {/* Greeting Section */}
@@ -225,7 +228,7 @@ export function DashboardHome() {
             <CardTitle className="text-sm font-medium">
               ⏰ Thời gian học
             </CardTitle>
-            <div className="text-2xl">📖</div>
+            <div className="text-2xl">���</div>
           </CardHeader>
           <CardContent>
             <div className="text-3xl font-bold text-primary">45h</div>

--- a/client/components/DashboardHome.tsx
+++ b/client/components/DashboardHome.tsx
@@ -405,7 +405,10 @@ export function DashboardHome() {
                     </div>
 
                     {/* Action Button */}
-                    <Button onClick={() => navigate("/study-plan")} className="w-full bg-gradient-to-r from-primary to-accent hover:from-primary/80 hover:to-accent/80 text-white font-medium rounded-xl transition-all duration-300 hover:scale-105">
+                    <Button
+                      onClick={() => navigate("/study-plan")}
+                      className="w-full bg-gradient-to-r from-primary to-accent hover:from-primary/80 hover:to-accent/80 text-white font-medium rounded-xl transition-all duration-300 hover:scale-105"
+                    >
                       <Play className="h-4 w-4 mr-2" />
                       {course.progress === 0
                         ? "🚀 Bắt đầu học!"

--- a/client/pages/Learn.tsx
+++ b/client/pages/Learn.tsx
@@ -5,7 +5,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
-import { ArrowLeft, ZoomIn, ZoomOut, Clock } from "lucide-react";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/hooks/use-toast";
+import { ArrowLeft, ZoomIn, ZoomOut, Clock, Lightbulb, Heart } from "lucide-react";
+import type { GetLessonResponse } from "@shared/api";
 
 interface LearnState {
   type: "video" | "document";
@@ -13,6 +17,7 @@ interface LearnState {
   description?: string;
   src: string;
   estimatedDurationSec?: number; // for documents
+  lessonId?: string; // optional, to fetch/access-check and sync progress
 }
 
 function formatTime(sec: number) {
@@ -23,6 +28,7 @@ function formatTime(sec: number) {
 
 export default function Learn() {
   const navigate = useNavigate();
+  const { toast } = useToast();
   const { state } = useLocation();
   const learn = (state || {}) as LearnState;
 
@@ -32,13 +38,94 @@ export default function Learn() {
 
   const [zoom, setZoom] = useState(1);
   const [elapsed, setElapsed] = useState(0);
-  const estimated = learn.estimatedDurationSec || 600; // default 10min
+  const [breakShown, setBreakShown] = useState(false);
+  const [milestonesShown, setMilestonesShown] = useState<Record<number, boolean>>({});
 
+  const [accessError, setAccessError] = useState<string | null>(null);
+  const [serverVideo, setServerVideo] = useState<string | null>(null);
+
+  const [showReflection, setShowReflection] = useState(false);
+  const [reflectionNote, setReflectionNote] = useState("");
+
+  const [quickAnswers, setQuickAnswers] = useState<Record<number, number | null>>({ 0: null, 1: null });
+  const [quickSubmitted, setQuickSubmitted] = useState(false);
+  const [understoodOk, setUnderstoodOk] = useState<boolean | null>(null);
+
+  const estimated = learn.estimatedDurationSec || 600; // default 10min for documents
+
+  // Optional access-check + hydrate from server
+  useEffect(() => {
+    let cancelled = false;
+    if (!learn.lessonId) return;
+    fetch(`/api/lessons/${learn.lessonId}`)
+      .then(async (r) => {
+        if (!r.ok) {
+          if (r.status === 403) throw new Error("Bài học chưa sẵn sàng");
+          throw new Error("Không tải được bài học");
+        }
+        return (await r.json()) as GetLessonResponse;
+      })
+      .then((res) => {
+        if (cancelled) return;
+        if (learn.type === "video") setServerVideo(res.lesson.videoUrl);
+        setAccessError(null);
+      })
+      .catch((e: any) => {
+        if (cancelled) return;
+        setAccessError(e?.message || "Không thể truy cập bài học");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [learn.lessonId, learn.type]);
+
+  // Document ticking
   useEffect(() => {
     if (learn.type !== "document") return;
     const iv = setInterval(() => setElapsed((e) => e + 1), 1000);
     return () => clearInterval(iv);
   }, [learn.type]);
+
+  // Motivational toasts (5, 15, 25 minutes)
+  useEffect(() => {
+    const total = learn.type === "video" ? Math.floor(videoPos) : elapsed;
+    const marks = [300, 900, 1500];
+    marks.forEach((t) => {
+      if (total >= t && !milestonesShown[t]) {
+        setMilestonesShown((s) => ({ ...s, [t]: true }));
+        toast({
+          title: "Cố lên!",
+          description: t === 1500 ? "Bạn sắp chạm mốc 25 phút, chuẩn bị nghỉ ngơi nhé!" : "Bạn đang làm rất tốt!",
+        });
+      }
+    });
+    if (total >= 1500 && !breakShown) setBreakShown(true);
+  }, [learn.type, videoPos, elapsed, milestonesShown, breakShown, toast]);
+
+  // Save progress (server optional)
+  useEffect(() => {
+    if (!learn.lessonId) return;
+    const iv = setInterval(() => {
+      const positionSec = learn.type === "video" ? videoPos : elapsed;
+      const completed = learn.type === "video" ? videoDur > 0 && videoPos >= videoDur - 0.5 : elapsed >= estimated - 1;
+      fetch(`/api/lessons/${learn.lessonId}/progress`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ positionSec, completed }),
+      }).catch(() => {});
+    }, 5000);
+    return () => clearInterval(iv);
+  }, [learn.lessonId, learn.type, videoPos, videoDur, elapsed, estimated]);
+
+  // Reflection trigger at 50%
+  useEffect(() => {
+    const ratio = learn.type === "video" ? (videoDur > 0 ? videoPos / videoDur : 0) : elapsed / Math.max(1, estimated);
+    if (!showReflection && ratio >= 0.5) {
+      const stored = localStorage.getItem(`reflection:${learn.title}`) || "";
+      setReflectionNote(stored);
+      setShowReflection(true);
+    }
+  }, [learn.type, videoPos, videoDur, elapsed, estimated, showReflection, learn.title]);
 
   const progress = useMemo(() => {
     if (learn.type === "video") {
@@ -47,6 +134,46 @@ export default function Learn() {
     }
     return Math.max(0, Math.min(100, (elapsed / Math.max(1, estimated)) * 100));
   }, [learn.type, videoPos, videoDur, elapsed, estimated]);
+
+  const computedSrc = useMemo(() => {
+    if (learn.type === "video") return serverVideo || learn.src;
+    return learn.src;
+  }, [learn.type, serverVideo, learn.src]);
+
+  const conceptHints = useMemo(() => {
+    const text = `${learn.title || ""} ${learn.description || ""}`.toLowerCase();
+    const hints: { title: string; story: string; emoji: string }[] = [];
+    if (/cộng|add|addition/.test(text)) {
+      hints.push({
+        title: "Ghép mảnh để cộng",
+        story:
+          "Hãy tưởng tượng 10 khối lego màu xanh và 5 khối lego màu đỏ. Ghép lại, bạn sẽ có 15 khối rực rỡ!",
+        emoji: "🧩",
+      });
+    }
+    if (/trừ|subtract|subtraction/.test(text)) {
+      hints.push({
+        title: "Ăn bánh còn bao nhiêu?",
+        story: "Có 9 chiếc bánh, bạn ăn 3 chiếc. Còn lại mấy chiếc để chia cho bạn bè?",
+        emoji: "🧁",
+      });
+    }
+    if (/phân số|fraction/.test(text)) {
+      hints.push({
+        title: "Cắt bánh chia phần",
+        story: "Một chiếc pizza chia 8 miếng. 3/8 nghĩa là 3 miếng pizza ngon tuyệt!",
+        emoji: "🍕",
+      });
+    }
+    if (!hints.length) {
+      hints.push({
+        title: "Gợi ý minh họa",
+        story: "Khi gặp khái niệm khó, hãy tưởng tượng nó như đồ vật quen thuộc hằng ngày để dễ hình dung hơn.",
+        emoji: "💡",
+      });
+    }
+    return hints;
+  }, [learn.title, learn.description]);
 
   if (!learn || !learn.src || !learn.type) {
     return (
@@ -64,9 +191,26 @@ export default function Learn() {
     );
   }
 
+  if (accessError) {
+    return (
+      <DashboardLayout>
+        <div className="p-6">
+          <Card className="border-red-200">
+            <CardContent className="p-6 text-center">
+              <div className="text-5xl mb-2">🔒</div>
+              <div className="font-bold text-red-600 mb-2">{accessError}</div>
+              <Button variant="outline" onClick={() => navigate(-1)}>Quay lại</Button>
+            </CardContent>
+          </Card>
+        </div>
+      </DashboardLayout>
+    );
+  }
+
   return (
     <DashboardLayout>
       <div className="flex-1 space-y-6 p-6 bg-gradient-to-br from-background via-accent/5 to-primary/5">
+        {/* Top bar */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <Button
@@ -91,6 +235,7 @@ export default function Learn() {
           </Badge>
         </div>
 
+        {/* Study progress */}
         <Card className="border-primary/20 bg-gradient-to-r from-primary/5 to-accent/5">
           <CardContent className="p-4">
             <div className="flex items-center justify-between mb-2">
@@ -103,13 +248,27 @@ export default function Learn() {
           </CardContent>
         </Card>
 
+        {/* Break reminder */}
+        {breakShown && (
+          <Card className="border-yellow-200 bg-yellow-50">
+            <CardContent className="p-4 flex items-center justify-between">
+              <div className="flex items-center gap-2 text-yellow-800">
+                <Heart className="h-5 w-5" />
+                <span>Đã 25 phút rồi! Nghỉ 5 phút cho mắt và não nhé 💆‍♀️</span>
+              </div>
+              <Button size="sm" variant="outline" onClick={() => setBreakShown(false)}>Đã hiểu</Button>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Main content */}
         {learn.type === "video" ? (
           <Card className="border-primary/20 overflow-hidden shadow-lg">
             <CardContent className="p-0">
               <div className="aspect-video bg-black">
                 <video
                   ref={videoRef}
-                  src={learn.src}
+                  src={computedSrc}
                   controls
                   className="w-full h-full"
                   onLoadedMetadata={() => setVideoDur(videoRef.current?.duration || 0)}
@@ -143,7 +302,7 @@ export default function Learn() {
                   className="w-full h-full"
                   style={{ transform: `scale(${zoom})`, transformOrigin: "top left" }}
                 >
-                  <iframe src={learn.src} className="w-[100%] h-[75vh]" />
+                  <iframe src={computedSrc} className="w-[100%] h-[75vh]" />
                 </div>
               </div>
               <div className="p-4 flex items-center gap-4 text-sm text-muted-foreground">
@@ -155,7 +314,121 @@ export default function Learn() {
             </CardContent>
           </Card>
         )}
+
+        {/* Concept helper */}
+        <Card className="border-secondary/20">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base"><Lightbulb className="h-4 w-4 text-secondary" /> Gợi ý hình ảnh/câu chuyện</CardTitle>
+          </CardHeader>
+          <CardContent className="grid gap-3 md:grid-cols-3">
+            {conceptHints.map((h, i) => (
+              <div key={i} className="p-3 rounded-xl border bg-white/70">
+                <div className="text-2xl mb-1">{h.emoji}</div>
+                <div className="font-semibold">{h.title}</div>
+                <div className="text-sm text-muted-foreground mt-1">{h.story}</div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        {/* Quick check (simple 2-question quiz) */}
+        <Card className="border-primary/20">
+          <CardHeader>
+            <CardTitle className="text-base">Kiểm tra nhanh mức độ hiểu bài</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {[0, 1].map((idx) => (
+              <div key={idx} className="p-3 rounded-lg border">
+                <div className="font-medium">Câu {idx + 1}</div>
+                <div className="mt-2 space-y-2">
+                  {[0, 1, 2].map((opt) => (
+                    <label key={opt} className="flex items-center gap-2 text-sm">
+                      <input
+                        type="radio"
+                        name={`q-${idx}`}
+                        checked={quickAnswers[idx] === opt}
+                        onChange={() => setQuickAnswers((s) => ({ ...s, [idx]: opt }))}
+                      />
+                      <span>Lựa chọn {opt + 1}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            ))}
+            <div className="flex items-center gap-2">
+              <Button
+                onClick={() => {
+                  setQuickSubmitted(true);
+                  const correct = (Number(quickAnswers[0] === 0) + Number(quickAnswers[1] === 1)) >= 2;
+                  setUnderstoodOk(correct);
+                  toast({
+                    title: correct ? "Tuyệt vời!" : "Cần ôn thêm",
+                    description: correct ? "Bạn đã hiểu tốt. Tiếp tục bài tiếp theo nhé!" : "Hãy xem lại nội dung hoặc làm thêm bài tập.",
+                    variant: correct ? "default" : "destructive",
+                  });
+                }}
+              >
+                Nộp bài
+              </Button>
+              {quickSubmitted && understoodOk === false && (
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    if (learn.lessonId) navigate(`/lesson/${learn.lessonId}/exercise/1`);
+                    else navigate("/study-plan");
+                  }}
+                >
+                  Làm thêm bài tập
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Next actions */}
+        <div className="flex items-center gap-3">
+          <Button
+            disabled={understoodOk !== true}
+            onClick={() => navigate("/study-plan")}
+            className="bg-gradient-to-r from-primary to-accent text-white"
+          >
+            Tiếp tục bài tiếp theo
+          </Button>
+          <Button variant="outline" onClick={() => navigate("/study-plan")}>Quay lại lộ trình</Button>
+        </div>
       </div>
+
+      {/* Reflection dialog */}
+      <Dialog open={showReflection} onOpenChange={setShowReflection}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Tự phản ánh</DialogTitle>
+            <DialogDescription>
+              Hãy dành một phút để nghĩ về điều bạn đã hiểu rõ và điều còn mơ hồ. Ghi lại vài dòng nhé!
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Textarea
+              rows={5}
+              value={reflectionNote}
+              onChange={(e) => setReflectionNote(e.target.value)}
+              placeholder="Điều mình đã hiểu... Điều còn mơ hồ..."
+            />
+            <div className="flex justify-end gap-2 pt-2">
+              <Button variant="outline" onClick={() => setShowReflection(false)}>Để sau</Button>
+              <Button
+                onClick={() => {
+                  localStorage.setItem(`reflection:${learn.title}`, reflectionNote);
+                  setShowReflection(false);
+                }}
+                className="bg-gradient-to-r from-primary to-accent text-white"
+              >
+                Lưu ghi chú
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </DashboardLayout>
   );
 }

--- a/client/pages/Learn.tsx
+++ b/client/pages/Learn.tsx
@@ -5,10 +5,23 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
-import { ArrowLeft, ZoomIn, ZoomOut, Clock, Lightbulb, Heart } from "lucide-react";
+import {
+  ArrowLeft,
+  ZoomIn,
+  ZoomOut,
+  Clock,
+  Lightbulb,
+  Heart,
+} from "lucide-react";
 import type { GetLessonResponse } from "@shared/api";
 
 interface LearnState {
@@ -41,9 +54,14 @@ export default function Learn() {
   const [zoom, setZoom] = useState(1);
   const [elapsed, setElapsed] = useState(0);
   const [breakShown, setBreakShown] = useState(false);
-  const [milestonesShown, setMilestonesShown] = useState<Record<number, boolean>>({});
+  const [milestonesShown, setMilestonesShown] = useState<
+    Record<number, boolean>
+  >({});
   const [hintsEnabled, setHintsEnabled] = useState(true);
-  const markerTimes = useMemo(() => (Array.isArray(learn.promptTimesSec) ? learn.promptTimesSec : []), [learn.promptTimesSec]);
+  const markerTimes = useMemo(
+    () => (Array.isArray(learn.promptTimesSec) ? learn.promptTimesSec : []),
+    [learn.promptTimesSec],
+  );
 
   const [accessError, setAccessError] = useState<string | null>(null);
   const [serverVideo, setServerVideo] = useState<string | null>(null);
@@ -51,9 +69,14 @@ export default function Learn() {
   const [showReflection, setShowReflection] = useState(false);
   const [reflectionNote, setReflectionNote] = useState("");
   const [reflectionPrompted, setReflectionPrompted] = useState(false);
-  const reflectFlag = useMemo(() => `reflection:prompted:${learn.title}`, [learn.title]);
+  const reflectFlag = useMemo(
+    () => `reflection:prompted:${learn.title}`,
+    [learn.title],
+  );
 
-  const [quickAnswers, setQuickAnswers] = useState<Record<number, number | null>>({ 0: null, 1: null });
+  const [quickAnswers, setQuickAnswers] = useState<
+    Record<number, number | null>
+  >({ 0: null, 1: null });
   const [quickSubmitted, setQuickSubmitted] = useState(false);
   const [understoodOk, setUnderstoodOk] = useState<boolean | null>(null);
 
@@ -76,7 +99,8 @@ export default function Learn() {
       })
       .catch((e: any) => {
         if (cancelled) return;
-        if (String(e?.message || "").includes("sẵn sàng")) setAccessError("Bài học chưa sẵn sàng");
+        if (String(e?.message || "").includes("sẵn sàng"))
+          setAccessError("Bài học chưa sẵn sàng");
         else setAccessError(null);
       });
     return () => {
@@ -93,9 +117,11 @@ export default function Learn() {
 
   // Whether there are any concepts detected (safe before conceptHints init)
   const hasConcepts = useMemo(() => {
-    const text = `${learn.title || ""} ${learn.description || ""}`.toLowerCase();
+    const text =
+      `${learn.title || ""} ${learn.description || ""}`.toLowerCase();
     const tagCount = (learn.conceptTags || []).length;
-    const pattern = /(cộng|add|addition|trừ|subtract|subtraction|phân số|fraction)/;
+    const pattern =
+      /(cộng|add|addition|trừ|subtract|subtraction|phân số|fraction)/;
     return tagCount > 0 || pattern.test(text);
   }, [learn.title, learn.description, learn.conceptTags]);
 
@@ -108,7 +134,10 @@ export default function Learn() {
         setMilestonesShown((s) => ({ ...s, [t]: true }));
         toast({
           title: "Cố lên!",
-          description: t === 1500 ? "Bạn sắp chạm mốc 25 phút, chuẩn bị nghỉ ngơi nhé!" : "Bạn đang làm rất tốt!",
+          description:
+            t === 1500
+              ? "Bạn sắp chạm mốc 25 phút, chuẩn bị nghỉ ngơi nhé!"
+              : "Bạn đang làm rất tốt!",
         });
       }
     });
@@ -120,7 +149,10 @@ export default function Learn() {
     if (!learn.lessonId) return;
     const iv = setInterval(() => {
       const positionSec = learn.type === "video" ? videoPos : elapsed;
-      const completed = learn.type === "video" ? videoDur > 0 && videoPos >= videoDur - 0.5 : elapsed >= estimated - 1;
+      const completed =
+        learn.type === "video"
+          ? videoDur > 0 && videoPos >= videoDur - 0.5
+          : elapsed >= estimated - 1;
       fetch(`/api/lessons/${learn.lessonId}/progress`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -137,7 +169,12 @@ export default function Learn() {
 
   // Reflection trigger at 50%
   useEffect(() => {
-    const ratio = learn.type === "video" ? (videoDur > 0 ? videoPos / videoDur : 0) : elapsed / Math.max(1, estimated);
+    const ratio =
+      learn.type === "video"
+        ? videoDur > 0
+          ? videoPos / videoDur
+          : 0
+        : elapsed / Math.max(1, estimated);
     if (!showReflection && !reflectionPrompted && ratio >= 0.5) {
       const stored = localStorage.getItem(`reflection:${learn.title}`) || "";
       setReflectionNote(stored);
@@ -145,7 +182,17 @@ export default function Learn() {
       setReflectionPrompted(true);
       localStorage.setItem(reflectFlag, "1");
     }
-  }, [learn.type, videoPos, videoDur, elapsed, estimated, showReflection, learn.title, reflectionPrompted, reflectFlag]);
+  }, [
+    learn.type,
+    videoPos,
+    videoDur,
+    elapsed,
+    estimated,
+    showReflection,
+    learn.title,
+    reflectionPrompted,
+    reflectFlag,
+  ]);
 
   const progress = useMemo(() => {
     if (learn.type === "video") {
@@ -162,7 +209,8 @@ export default function Learn() {
 
   // Concept hints derived from title/description/tags
   const hintsArr = useMemo(() => {
-    const text = `${learn.title || ""} ${learn.description || ""}`.toLowerCase();
+    const text =
+      `${learn.title || ""} ${learn.description || ""}`.toLowerCase();
     const tags = new Set<string>();
     (learn.conceptTags || []).forEach((t) => tags.add(t.toLowerCase()));
     if (/cộng|add|addition/.test(text)) tags.add("addition");
@@ -181,14 +229,16 @@ export default function Learn() {
     if (tags.has("subtraction")) {
       hints.push({
         title: "Ăn bánh còn bao nhiêu?",
-        story: "Có 9 chiếc bánh, bạn ăn 3 chiếc. Còn lại mấy chiếc để chia cho bạn bè?",
+        story:
+          "Có 9 chiếc bánh, bạn ăn 3 chiếc. Còn lại mấy chiếc để chia cho bạn bè?",
         emoji: "🧁",
       });
     }
     if (tags.has("fraction")) {
       hints.push({
         title: "Cắt bánh chia phần",
-        story: "Một chiếc pizza chia 8 miếng. 3/8 nghĩa là 3 miếng pizza ngon tuyệt!",
+        story:
+          "Một chiếc pizza chia 8 miếng. 3/8 nghĩa là 3 miếng pizza ngon tuyệt!",
         emoji: "🍕",
       });
     }
@@ -203,7 +253,9 @@ export default function Learn() {
             <CardContent className="p-6 flex flex-col items-center gap-4 text-center">
               <div className="text-5xl">🤔</div>
               <div>Thiếu thông tin bài học.</div>
-              <Button onClick={() => navigate("/study-plan")}>Quay lại lộ trình</Button>
+              <Button onClick={() => navigate("/study-plan")}>
+                Quay lại lộ trình
+              </Button>
             </CardContent>
           </Card>
         </div>
@@ -219,7 +271,9 @@ export default function Learn() {
             <CardContent className="p-6 text-center">
               <div className="text-5xl mb-2">🔒</div>
               <div className="font-bold text-red-600 mb-2">{accessError}</div>
-              <Button variant="outline" onClick={() => navigate(-1)}>Quay lại</Button>
+              <Button variant="outline" onClick={() => navigate(-1)}>
+                Quay lại
+              </Button>
             </CardContent>
           </Card>
         </div>
@@ -246,7 +300,9 @@ export default function Learn() {
                 {learn.title}
               </h1>
               {learn.description && (
-                <div className="text-sm text-muted-foreground mt-1">{learn.description}</div>
+                <div className="text-sm text-muted-foreground mt-1">
+                  {learn.description}
+                </div>
               )}
             </div>
           </div>
@@ -258,181 +314,231 @@ export default function Learn() {
         <div className="grid gap-6 lg:grid-cols-3">
           <div className="lg:col-span-2 space-y-6">
             {/* Study progress */}
-        <Card className="border-primary/20 bg-gradient-to-r from-primary/5 to-accent/5 sticky top-16 z-10 backdrop-blur supports-[backdrop-filter]:bg-white/60">
-          <CardContent className="p-4">
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-sm font-medium">Tiến độ</span>
-              <span className="text-sm font-bold text-primary">{Math.round(progress)}%</span>
-            </div>
-            <div className="relative">
-              <Progress value={progress} className="h-3" />
-              {markerTimes.map((t, i) => {
-                const total = learn.type === "video" ? Math.max(1, videoDur) : Math.max(1, estimated);
-                const pct = Math.max(0, Math.min(100, (t / total) * 100));
-                return (
-                  <div
-                    key={i}
-                    className="absolute top-[-4px] h-4 w-[2px] bg-accent"
-                    style={{ left: `${pct}%` }}
-                    title={`Mốc: ${formatTime(t)}`}
-                  />
-                );
-              })}
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Break reminder */}
-        {breakShown && (
-          <Card className="border-yellow-200 bg-yellow-50">
-            <CardContent className="p-4 flex items-center justify-between">
-              <div className="flex items-center gap-2 text-yellow-800">
-                <Heart className="h-5 w-5" />
-                <span>Đã 25 phút rồi! Nghỉ 5 phút cho mắt và não nhé 💆‍♀���</span>
-              </div>
-              <Button size="sm" variant="outline" onClick={() => setBreakShown(false)}>Đã hiểu</Button>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Main content */}
-        {learn.type === "video" ? (
-          <Card className="border-primary/20 overflow-hidden shadow-lg">
-            <CardContent className="p-0">
-              <div className="aspect-video bg-black">
-                <video
-                  ref={videoRef}
-                  src={computedSrc}
-                  controls
-                  className="w-full h-full"
-                  onLoadedMetadata={() => setVideoDur(videoRef.current?.duration || 0)}
-                  onTimeUpdate={() => setVideoPos(videoRef.current?.currentTime || 0)}
-                />
-              </div>
-              <div className="p-4 flex items-center gap-4 text-sm text-muted-foreground">
-                <span className="flex items-center gap-1">
-                  <Clock className="h-4 w-4" />
-                  {formatTime(videoPos)} / {formatTime(videoDur)}
-                </span>
-              </div>
-            </CardContent>
-          </Card>
-        ) : (
-          <Card className="border-accent/30 overflow-hidden shadow-lg">
-            <CardHeader className="flex flex-row items-center justify-between py-3">
-              <CardTitle className="text-base">Tài liệu</CardTitle>
-              <div className="flex items-center gap-2">
-                <Button size="sm" variant="outline" onClick={() => setZoom((z) => Math.max(0.5, z - 0.1))}>
-                  <ZoomOut className="h-4 w-4" /> Thu nhỏ
-                </Button>
-                <Button size="sm" onClick={() => setZoom((z) => Math.min(2, z + 0.1))}>
-                  <ZoomIn className="h-4 w-4" /> Phóng to
-                </Button>
-              </div>
-            </CardHeader>
-            <CardContent className="p-0">
-              <div className="w-full h-[75vh] overflow-auto bg-white">
-                <div
-                  className="w-full h-full"
-                  style={{ transform: `scale(${zoom})`, transformOrigin: "top left" }}
-                >
-                  <iframe src={computedSrc} className="w-[100%] h-[75vh]" />
+            <Card className="border-primary/20 bg-gradient-to-r from-primary/5 to-accent/5 sticky top-16 z-10 backdrop-blur supports-[backdrop-filter]:bg-white/60">
+              <CardContent className="p-4">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-sm font-medium">Tiến độ</span>
+                  <span className="text-sm font-bold text-primary">
+                    {Math.round(progress)}%
+                  </span>
                 </div>
-              </div>
-              <div className="p-4 flex items-center gap-4 text-sm text-muted-foreground">
-                <span className="flex items-center gap-1">
-                  <Clock className="h-4 w-4" />
-                  {formatTime(elapsed)} / {formatTime(estimated)} (ước tính)
-                </span>
-              </div>
-            </CardContent>
-          </Card>
-        )}
-
-
-        {/* Quick check (simple 2-question quiz) */}
-        <Card className="border-primary/20">
-          <CardHeader>
-            <CardTitle className="text-base">Kiểm tra nhanh mức độ hiểu bài</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {[0, 1].map((idx) => (
-              <div key={idx} className="p-3 rounded-lg border">
-                <div className="font-medium">Câu {idx + 1}</div>
-                <div className="mt-2 space-y-2">
-                  {[0, 1, 2].map((opt) => (
-                    <label key={opt} className="flex items-center gap-2 text-sm">
-                      <input
-                        type="radio"
-                        name={`q-${idx}`}
-                        checked={quickAnswers[idx] === opt}
-                        onChange={() => setQuickAnswers((s) => ({ ...s, [idx]: opt }))}
+                <div className="relative">
+                  <Progress value={progress} className="h-3" />
+                  {markerTimes.map((t, i) => {
+                    const total =
+                      learn.type === "video"
+                        ? Math.max(1, videoDur)
+                        : Math.max(1, estimated);
+                    const pct = Math.max(0, Math.min(100, (t / total) * 100));
+                    return (
+                      <div
+                        key={i}
+                        className="absolute top-[-4px] h-4 w-[2px] bg-accent"
+                        style={{ left: `${pct}%` }}
+                        title={`Mốc: ${formatTime(t)}`}
                       />
-                      <span>Lựa chọn {opt + 1}</span>
-                    </label>
-                  ))}
+                    );
+                  })}
                 </div>
-              </div>
-            ))}
-            <div className="flex items-center gap-2">
-              <Button
-                onClick={() => {
-                  setQuickSubmitted(true);
-                  const correct = (Number(quickAnswers[0] === 0) + Number(quickAnswers[1] === 1)) >= 2;
-                  setUnderstoodOk(correct);
-                  toast({
-                    title: correct ? "Tuyệt vời!" : "Cần ôn thêm",
-                    description: correct ? "Bạn đã hiểu tốt. Tiếp tục bài tiếp theo nhé!" : "Hãy xem lại nội dung hoặc làm thêm bài tập.",
-                    variant: correct ? "default" : "destructive",
-                  });
-                }}
-              >
-                Nộp bài
-              </Button>
-              {quickSubmitted && understoodOk === false && (
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    if (learn.lessonId) navigate(`/lesson/${learn.lessonId}/exercise/1`);
-                    else navigate("/study-plan");
-                  }}
-                >
-                  Làm thêm bài tập
-                </Button>
-              )}
-            </div>
-          </CardContent>
-        </Card>
+              </CardContent>
+            </Card>
 
-        {/* Next actions */}
-        <div className="flex items-center gap-3">
-          <Button
-            disabled={understoodOk !== true}
-            onClick={() => navigate("/study-plan")}
-            className="bg-gradient-to-r from-primary to-accent text-white"
-          >
-            Tiếp tục bài tiếp theo
-          </Button>
-          <Button variant="outline" onClick={() => navigate("/study-plan")}>
-            Quay lại lộ trình
-          </Button>
-        </div>
+            {/* Break reminder */}
+            {breakShown && (
+              <Card className="border-yellow-200 bg-yellow-50">
+                <CardContent className="p-4 flex items-center justify-between">
+                  <div className="flex items-center gap-2 text-yellow-800">
+                    <Heart className="h-5 w-5" />
+                    <span>
+                      Đã 25 phút rồi! Nghỉ 5 phút cho mắt và não nhé 💆‍♀���
+                    </span>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setBreakShown(false)}
+                  >
+                    Đã hiểu
+                  </Button>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Main content */}
+            {learn.type === "video" ? (
+              <Card className="border-primary/20 overflow-hidden shadow-lg">
+                <CardContent className="p-0">
+                  <div className="aspect-video bg-black">
+                    <video
+                      ref={videoRef}
+                      src={computedSrc}
+                      controls
+                      className="w-full h-full"
+                      onLoadedMetadata={() =>
+                        setVideoDur(videoRef.current?.duration || 0)
+                      }
+                      onTimeUpdate={() =>
+                        setVideoPos(videoRef.current?.currentTime || 0)
+                      }
+                    />
+                  </div>
+                  <div className="p-4 flex items-center gap-4 text-sm text-muted-foreground">
+                    <span className="flex items-center gap-1">
+                      <Clock className="h-4 w-4" />
+                      {formatTime(videoPos)} / {formatTime(videoDur)}
+                    </span>
+                  </div>
+                </CardContent>
+              </Card>
+            ) : (
+              <Card className="border-accent/30 overflow-hidden shadow-lg">
+                <CardHeader className="flex flex-row items-center justify-between py-3">
+                  <CardTitle className="text-base">Tài liệu</CardTitle>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setZoom((z) => Math.max(0.5, z - 0.1))}
+                    >
+                      <ZoomOut className="h-4 w-4" /> Thu nhỏ
+                    </Button>
+                    <Button
+                      size="sm"
+                      onClick={() => setZoom((z) => Math.min(2, z + 0.1))}
+                    >
+                      <ZoomIn className="h-4 w-4" /> Phóng to
+                    </Button>
+                  </div>
+                </CardHeader>
+                <CardContent className="p-0">
+                  <div className="w-full h-[75vh] overflow-auto bg-white">
+                    <div
+                      className="w-full h-full"
+                      style={{
+                        transform: `scale(${zoom})`,
+                        transformOrigin: "top left",
+                      }}
+                    >
+                      <iframe src={computedSrc} className="w-[100%] h-[75vh]" />
+                    </div>
+                  </div>
+                  <div className="p-4 flex items-center gap-4 text-sm text-muted-foreground">
+                    <span className="flex items-center gap-1">
+                      <Clock className="h-4 w-4" />
+                      {formatTime(elapsed)} / {formatTime(estimated)} (ước tính)
+                    </span>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Quick check (simple 2-question quiz) */}
+            <Card className="border-primary/20">
+              <CardHeader>
+                <CardTitle className="text-base">
+                  Kiểm tra nhanh mức độ hiểu bài
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {[0, 1].map((idx) => (
+                  <div key={idx} className="p-3 rounded-lg border">
+                    <div className="font-medium">Câu {idx + 1}</div>
+                    <div className="mt-2 space-y-2">
+                      {[0, 1, 2].map((opt) => (
+                        <label
+                          key={opt}
+                          className="flex items-center gap-2 text-sm"
+                        >
+                          <input
+                            type="radio"
+                            name={`q-${idx}`}
+                            checked={quickAnswers[idx] === opt}
+                            onChange={() =>
+                              setQuickAnswers((s) => ({ ...s, [idx]: opt }))
+                            }
+                          />
+                          <span>Lựa chọn {opt + 1}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+                <div className="flex items-center gap-2">
+                  <Button
+                    onClick={() => {
+                      setQuickSubmitted(true);
+                      const correct =
+                        Number(quickAnswers[0] === 0) +
+                          Number(quickAnswers[1] === 1) >=
+                        2;
+                      setUnderstoodOk(correct);
+                      toast({
+                        title: correct ? "Tuyệt vời!" : "Cần ôn thêm",
+                        description: correct
+                          ? "Bạn đã hiểu tốt. Tiếp tục bài tiếp theo nhé!"
+                          : "Hãy xem lại nội dung hoặc làm thêm bài tập.",
+                        variant: correct ? "default" : "destructive",
+                      });
+                    }}
+                  >
+                    Nộp bài
+                  </Button>
+                  {quickSubmitted && understoodOk === false && (
+                    <Button
+                      variant="outline"
+                      onClick={() => {
+                        if (learn.lessonId)
+                          navigate(`/lesson/${learn.lessonId}/exercise/1`);
+                        else navigate("/study-plan");
+                      }}
+                    >
+                      Làm thêm bài tập
+                    </Button>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Next actions */}
+            <div className="flex items-center gap-3">
+              <Button
+                disabled={understoodOk !== true}
+                onClick={() => navigate("/study-plan")}
+                className="bg-gradient-to-r from-primary to-accent text-white"
+              >
+                Tiếp tục bài tiếp theo
+              </Button>
+              <Button variant="outline" onClick={() => navigate("/study-plan")}>
+                Quay lại lộ trình
+              </Button>
+            </div>
           </div>
           {hasConcepts && hintsEnabled && (
             <Card className="border-secondary/20 h-fit">
               <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-base"><Lightbulb className="h-4 w-4 text-secondary" /> Gợi ý hình ảnh/câu chuyện</CardTitle>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Lightbulb className="h-4 w-4 text-secondary" /> Gợi ý hình
+                  ảnh/câu chuyện
+                </CardTitle>
               </CardHeader>
               <CardContent className="grid gap-3">
                 {hintsArr.map((h, i) => (
                   <div key={i} className="p-3 rounded-xl border bg-white/70">
                     <div className="text-2xl mb-1">{h.emoji}</div>
                     <div className="font-semibold">{h.title}</div>
-                    <div className="text-sm text-muted-foreground mt-1">{h.story}</div>
+                    <div className="text-sm text-muted-foreground mt-1">
+                      {h.story}
+                    </div>
                   </div>
                 ))}
                 <div className="pt-1 flex gap-2">
-                  <Button size="sm" variant="ghost" onClick={() => setHintsEnabled(false)}>Ẩn gợi ý</Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setHintsEnabled(false)}
+                  >
+                    Ẩn gợi ý
+                  </Button>
                 </div>
               </CardContent>
             </Card>
@@ -441,18 +547,22 @@ export default function Learn() {
       </div>
 
       {/* Reflection dialog */}
-      <Dialog open={showReflection} onOpenChange={(o) => {
-        setShowReflection(o);
-        if (!o) {
-          setReflectionPrompted(true);
-          localStorage.setItem(reflectFlag, "1");
-        }
-      }}>
+      <Dialog
+        open={showReflection}
+        onOpenChange={(o) => {
+          setShowReflection(o);
+          if (!o) {
+            setReflectionPrompted(true);
+            localStorage.setItem(reflectFlag, "1");
+          }
+        }}
+      >
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
             <DialogTitle>Tự phản ánh</DialogTitle>
             <DialogDescription>
-              Hãy dành một phút để nghĩ về điều bạn đã hiểu rõ và điều còn mơ hồ. Ghi lại vài dòng nhé!
+              Hãy dành một phút để nghĩ về điều bạn đã hiểu rõ và điều còn mơ
+              hồ. Ghi lại vài dòng nhé!
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-2">
@@ -463,10 +573,22 @@ export default function Learn() {
               placeholder="Điều mình đã hiểu... Điều còn mơ hồ..."
             />
             <div className="flex justify-end gap-2 pt-2">
-              <Button variant="outline" onClick={() => { setShowReflection(false); setReflectionPrompted(true); localStorage.setItem(reflectFlag, "1"); }}>Để sau</Button>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setShowReflection(false);
+                  setReflectionPrompted(true);
+                  localStorage.setItem(reflectFlag, "1");
+                }}
+              >
+                Để sau
+              </Button>
               <Button
                 onClick={() => {
-                  localStorage.setItem(`reflection:${learn.title}`, reflectionNote);
+                  localStorage.setItem(
+                    `reflection:${learn.title}`,
+                    reflectionNote,
+                  );
                   setReflectionPrompted(true);
                   localStorage.setItem(reflectFlag, "1");
                   setShowReflection(false);

--- a/client/pages/Learn.tsx
+++ b/client/pages/Learn.tsx
@@ -169,7 +169,7 @@ export default function Learn() {
   }, [learn.type, serverVideo, learn.src]);
 
   // Concept hints derived from title/description/tags
-  const conceptHints = useMemo(() => {
+  const hintsArr = useMemo(() => {
     const text = `${learn.title || ""} ${learn.description || ""}`.toLowerCase();
     const tags = new Set<string>();
     (learn.conceptTags || []).forEach((t) => tags.add(t.toLowerCase()));
@@ -292,7 +292,7 @@ export default function Learn() {
         )}
 
         {/* Timed opt-in prompt for hints */}
-        {conceptHints.length > 0 && (
+        {hasConcepts && (
           <Dialog open={hintPromptOpen} onOpenChange={setHintPromptOpen}>
             <DialogContent className="sm:max-w-md">
               <DialogHeader>
@@ -432,13 +432,13 @@ export default function Learn() {
           </Button>
         </div>
           </div>
-          {conceptHints.length > 0 && hintsEnabled && (
+          {hasConcepts && hintsEnabled && (
             <Card className="border-secondary/20 h-fit">
               <CardHeader>
                 <CardTitle className="flex items-center gap-2 text-base"><Lightbulb className="h-4 w-4 text-secondary" /> Gợi ý hình ảnh/câu chuyện</CardTitle>
               </CardHeader>
               <CardContent className="grid gap-3">
-                {conceptHints.map((h, i) => (
+                {hintsArr.map((h, i) => (
                   <div key={i} className="p-3 rounded-xl border bg-white/70">
                     <div className="text-2xl mb-1">{h.emoji}</div>
                     <div className="font-semibold">{h.title}</div>

--- a/client/pages/Learn.tsx
+++ b/client/pages/Learn.tsx
@@ -168,6 +168,40 @@ export default function Learn() {
     return learn.src;
   }, [learn.type, serverVideo, learn.src]);
 
+  // Concept hints derived from title/description/tags
+  const conceptHints = useMemo(() => {
+    const text = `${learn.title || ""} ${learn.description || ""}`.toLowerCase();
+    const tags = new Set<string>();
+    (learn.conceptTags || []).forEach((t) => tags.add(t.toLowerCase()));
+    if (/cộng|add|addition/.test(text)) tags.add("addition");
+    if (/trừ|subtract|subtraction/.test(text)) tags.add("subtraction");
+    if (/phân số|fraction/.test(text)) tags.add("fraction");
+
+    const hints: { title: string; story: string; emoji: string }[] = [];
+    if (tags.has("addition")) {
+      hints.push({
+        title: "Ghép mảnh để cộng",
+        story:
+          "Hãy tưởng tượng 10 khối lego màu xanh và 5 khối lego màu đỏ. Ghép lại, bạn sẽ có 15 khối rực rỡ!",
+        emoji: "🧩",
+      });
+    }
+    if (tags.has("subtraction")) {
+      hints.push({
+        title: "Ăn bánh còn bao nhiêu?",
+        story: "Có 9 chiếc bánh, bạn ăn 3 chiếc. Còn lại mấy chiếc để chia cho bạn bè?",
+        emoji: "🧁",
+      });
+    }
+    if (tags.has("fraction")) {
+      hints.push({
+        title: "Cắt bánh chia phần",
+        story: "Một chiếc pizza chia 8 miếng. 3/8 nghĩa là 3 miếng pizza ngon tuyệt!",
+        emoji: "🍕",
+      });
+    }
+    return hints;
+  }, [learn.title, learn.description, learn.conceptTags]);
 
   if (!learn || !learn.src || !learn.type) {
     return (
@@ -250,7 +284,7 @@ export default function Learn() {
             <CardContent className="p-4 flex items-center justify-between">
               <div className="flex items-center gap-2 text-yellow-800">
                 <Heart className="h-5 w-5" />
-                <span>Đã 25 phút rồi! Nghỉ 5 phút cho mắt và não nhé 💆‍♀️</span>
+                <span>Đã 25 phút rồi! Nghỉ 5 phút cho mắt và não nhé 💆‍♀���</span>
               </div>
               <Button size="sm" variant="outline" onClick={() => setBreakShown(false)}>Đã hiểu</Button>
             </CardContent>

--- a/client/pages/Learn.tsx
+++ b/client/pages/Learn.tsx
@@ -94,6 +94,14 @@ export default function Learn() {
     return () => clearInterval(iv);
   }, [learn.type]);
 
+  // Whether there are any concepts detected (safe before conceptHints init)
+  const hasConcepts = useMemo(() => {
+    const text = `${learn.title || ""} ${learn.description || ""}`.toLowerCase();
+    const tagCount = (learn.conceptTags || []).length;
+    const pattern = /(cộng|add|addition|trừ|subtract|subtraction|phân số|fraction)/;
+    return tagCount > 0 || pattern.test(text);
+  }, [learn.title, learn.description, learn.conceptTags]);
+
   // Motivational toasts (5, 15, 25 minutes) + timed hint opt-in (1/2/3 minutes)
   useEffect(() => {
     const total = learn.type === "video" ? Math.floor(videoPos) : elapsed;
@@ -109,11 +117,11 @@ export default function Learn() {
     });
     if (total >= 1500 && !breakShown) setBreakShown(true);
 
-    if (conceptHints.length > 0 && !hintsEnabled && promptIndex < promptTimes.length) {
+    if (hasConcepts && !hintsEnabled && promptIndex < promptTimes.length) {
       const triggerAt = promptTimes[promptIndex];
       if (total >= triggerAt && !hintPromptOpen) setHintPromptOpen(true);
     }
-  }, [learn.type, videoPos, elapsed, milestonesShown, breakShown, toast, conceptHints.length, hintsEnabled, promptIndex, promptTimes, hintPromptOpen]);
+  }, [learn.type, videoPos, elapsed, milestonesShown, breakShown, toast, hasConcepts, hintsEnabled, promptIndex, promptTimes, hintPromptOpen]);
 
   // Save progress (server optional)
   useEffect(() => {

--- a/client/pages/Learn.tsx
+++ b/client/pages/Learn.tsx
@@ -160,39 +160,6 @@ export default function Learn() {
     return learn.src;
   }, [learn.type, serverVideo, learn.src]);
 
-  const conceptHints = useMemo(() => {
-    const text = `${learn.title || ""} ${learn.description || ""}`.toLowerCase();
-    const tags = new Set<string>();
-    (learn.conceptTags || []).forEach((t) => tags.add(t.toLowerCase()));
-    if (/cộng|add|addition/.test(text)) tags.add("addition");
-    if (/trừ|subtract|subtraction/.test(text)) tags.add("subtraction");
-    if (/phân số|fraction/.test(text)) tags.add("fraction");
-
-    const hints: { title: string; story: string; emoji: string }[] = [];
-    if (tags.has("addition")) {
-      hints.push({
-        title: "Ghép mảnh để cộng",
-        story:
-          "Hãy tưởng tượng 10 khối lego màu xanh và 5 khối lego màu đỏ. Ghép lại, bạn sẽ có 15 khối rực rỡ!",
-        emoji: "🧩",
-      });
-    }
-    if (tags.has("subtraction")) {
-      hints.push({
-        title: "Ăn bánh còn bao nhiêu?",
-        story: "Có 9 chiếc bánh, bạn ăn 3 chiếc. Còn lại mấy chiếc để chia cho bạn bè?",
-        emoji: "🧁",
-      });
-    }
-    if (tags.has("fraction")) {
-      hints.push({
-        title: "Cắt bánh chia phần",
-        story: "Một chiếc pizza chia 8 miếng. 3/8 nghĩa là 3 miếng pizza ngon tuyệt!",
-        emoji: "🍕",
-      });
-    }
-    return hints;
-  }, [learn.title, learn.description, learn.conceptTags]);
 
   if (!learn || !learn.src || !learn.type) {
     return (

--- a/client/pages/Learn.tsx
+++ b/client/pages/Learn.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { DashboardLayout } from "@/components/DashboardLayout";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { Badge } from "@/components/ui/badge";
+import { ArrowLeft, ZoomIn, ZoomOut, Clock } from "lucide-react";
+
+interface LearnState {
+  type: "video" | "document";
+  title: string;
+  description?: string;
+  src: string;
+  estimatedDurationSec?: number; // for documents
+}
+
+function formatTime(sec: number) {
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+export default function Learn() {
+  const navigate = useNavigate();
+  const { state } = useLocation();
+  const learn = (state || {}) as LearnState;
+
+  const [videoPos, setVideoPos] = useState(0);
+  const [videoDur, setVideoDur] = useState(0);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  const [zoom, setZoom] = useState(1);
+  const [elapsed, setElapsed] = useState(0);
+  const estimated = learn.estimatedDurationSec || 600; // default 10min
+
+  useEffect(() => {
+    if (learn.type !== "document") return;
+    const iv = setInterval(() => setElapsed((e) => e + 1), 1000);
+    return () => clearInterval(iv);
+  }, [learn.type]);
+
+  const progress = useMemo(() => {
+    if (learn.type === "video") {
+      if (videoDur <= 0) return 0;
+      return Math.max(0, Math.min(100, (videoPos / videoDur) * 100));
+    }
+    return Math.max(0, Math.min(100, (elapsed / Math.max(1, estimated)) * 100));
+  }, [learn.type, videoPos, videoDur, elapsed, estimated]);
+
+  if (!learn || !learn.src || !learn.type) {
+    return (
+      <DashboardLayout>
+        <div className="p-6">
+          <Card>
+            <CardContent className="p-6 flex flex-col items-center gap-4 text-center">
+              <div className="text-5xl">🤔</div>
+              <div>Thiếu thông tin bài học.</div>
+              <Button onClick={() => navigate("/study-plan")}>Quay lại lộ trình</Button>
+            </CardContent>
+          </Card>
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="flex-1 space-y-6 p-6 bg-gradient-to-br from-background via-accent/5 to-primary/5">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Button
+              variant="outline"
+              onClick={() => navigate(-1)}
+              className="border-primary/20 hover:bg-primary/5"
+            >
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Quay lại
+            </Button>
+            <div>
+              <h1 className="text-2xl md:text-3xl font-bold bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">
+                {learn.title}
+              </h1>
+              {learn.description && (
+                <div className="text-sm text-muted-foreground mt-1">{learn.description}</div>
+              )}
+            </div>
+          </div>
+          <Badge variant="outline" className="text-xs">
+            {learn.type === "video" ? "📹 Video" : "📄 Tài liệu"}
+          </Badge>
+        </div>
+
+        <Card className="border-primary/20 bg-gradient-to-r from-primary/5 to-accent/5">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm font-medium">Tiến độ</span>
+              <span className="text-sm font-bold text-primary">{Math.round(progress)}%</span>
+            </div>
+            <div className="relative">
+              <Progress value={progress} className="h-3" />
+            </div>
+          </CardContent>
+        </Card>
+
+        {learn.type === "video" ? (
+          <Card className="border-primary/20 overflow-hidden shadow-lg">
+            <CardContent className="p-0">
+              <div className="aspect-video bg-black">
+                <video
+                  ref={videoRef}
+                  src={learn.src}
+                  controls
+                  className="w-full h-full"
+                  onLoadedMetadata={() => setVideoDur(videoRef.current?.duration || 0)}
+                  onTimeUpdate={() => setVideoPos(videoRef.current?.currentTime || 0)}
+                />
+              </div>
+              <div className="p-4 flex items-center gap-4 text-sm text-muted-foreground">
+                <span className="flex items-center gap-1">
+                  <Clock className="h-4 w-4" />
+                  {formatTime(videoPos)} / {formatTime(videoDur)}
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+        ) : (
+          <Card className="border-accent/30 overflow-hidden shadow-lg">
+            <CardHeader className="flex flex-row items-center justify-between py-3">
+              <CardTitle className="text-base">Tài liệu</CardTitle>
+              <div className="flex items-center gap-2">
+                <Button size="sm" variant="outline" onClick={() => setZoom((z) => Math.max(0.5, z - 0.1))}>
+                  <ZoomOut className="h-4 w-4" /> Thu nhỏ
+                </Button>
+                <Button size="sm" onClick={() => setZoom((z) => Math.min(2, z + 0.1))}>
+                  <ZoomIn className="h-4 w-4" /> Phóng to
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent className="p-0">
+              <div className="w-full h-[75vh] overflow-auto bg-white">
+                <div
+                  className="w-full h-full"
+                  style={{ transform: `scale(${zoom})`, transformOrigin: "top left" }}
+                >
+                  <iframe src={learn.src} className="w-[100%] h-[75vh]" />
+                </div>
+              </div>
+              <div className="p-4 flex items-center gap-4 text-sm text-muted-foreground">
+                <span className="flex items-center gap-1">
+                  <Clock className="h-4 w-4" />
+                  {formatTime(elapsed)} / {formatTime(estimated)} (ước tính)
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/client/pages/Learn.tsx
+++ b/client/pages/Learn.tsx
@@ -174,13 +174,6 @@ export default function Learn() {
         emoji: "🍕",
       });
     }
-    if (!hints.length) {
-      hints.push({
-        title: "Gợi ý minh họa",
-        story: "Khi gặp khái niệm khó, hãy tưởng tượng nó như đồ vật quen thuộc hằng ngày để dễ hình dung hơn.",
-        emoji: "💡",
-      });
-    }
     return hints;
   }, [learn.title, learn.description]);
 
@@ -244,7 +237,9 @@ export default function Learn() {
           </Badge>
         </div>
 
-        {/* Study progress */}
+        <div className="grid gap-6 lg:grid-cols-3">
+          <div className="lg:col-span-2 space-y-6">
+            {/* Study progress */}
         <Card className="border-primary/20 bg-gradient-to-r from-primary/5 to-accent/5">
           <CardContent className="p-4">
             <div className="flex items-center justify-between mb-2">
@@ -324,21 +319,6 @@ export default function Learn() {
           </Card>
         )}
 
-        {/* Concept helper */}
-        <Card className="border-secondary/20">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base"><Lightbulb className="h-4 w-4 text-secondary" /> Gợi ý hình ảnh/câu chuyện</CardTitle>
-          </CardHeader>
-          <CardContent className="grid gap-3 md:grid-cols-3">
-            {conceptHints.map((h, i) => (
-              <div key={i} className="p-3 rounded-xl border bg-white/70">
-                <div className="text-2xl mb-1">{h.emoji}</div>
-                <div className="font-semibold">{h.title}</div>
-                <div className="text-sm text-muted-foreground mt-1">{h.story}</div>
-              </div>
-            ))}
-          </CardContent>
-        </Card>
 
         {/* Quick check (simple 2-question quiz) */}
         <Card className="border-primary/20">
@@ -372,7 +352,7 @@ export default function Learn() {
                   setUnderstoodOk(correct);
                   toast({
                     title: correct ? "Tuyệt vời!" : "Cần ôn thêm",
-                    description: correct ? "Bạn đã hiểu tốt. Tiếp tục bài tiếp theo nh��!" : "Hãy xem lại nội dung hoặc làm thêm bài tập.",
+                    description: correct ? "Bạn đã hiểu tốt. Tiếp tục bài tiếp theo nhé!" : "Hãy xem lại nội dung hoặc làm thêm bài tập.",
                     variant: correct ? "default" : "destructive",
                   });
                 }}
@@ -403,7 +383,27 @@ export default function Learn() {
           >
             Tiếp tục bài tiếp theo
           </Button>
-          <Button variant="outline" onClick={() => navigate("/study-plan")}>Quay lại lộ trình</Button>
+          <Button variant="outline" onClick={() => navigate("/study-plan")}>
+            Quay lại lộ trình
+          </Button>
+        </div>
+          </div>
+          {conceptHints.length > 0 && (
+            <Card className="border-secondary/20 h-fit">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base"><Lightbulb className="h-4 w-4 text-secondary" /> Gợi ý hình ảnh/câu chuyện</CardTitle>
+              </CardHeader>
+              <CardContent className="grid gap-3">
+                {conceptHints.map((h, i) => (
+                  <div key={i} className="p-3 rounded-xl border bg-white/70">
+                    <div className="text-2xl mb-1">{h.emoji}</div>
+                    <div className="font-semibold">{h.title}</div>
+                    <div className="text-sm text-muted-foreground mt-1">{h.story}</div>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          )}
         </div>
       </div>
 

--- a/client/pages/StudyPlan.tsx
+++ b/client/pages/StudyPlan.tsx
@@ -334,16 +334,29 @@ export default function StudyPlan() {
 
   useEffect(() => {}, []);
 
-  const openVideo = (url?: string) => {
+  const openVideo = (url?: string, title?: string, description?: string, estimatedMin?: number) => {
     if (!url) return;
-    setVideoSrc(url);
-    setShowVideoDialog(true);
+    navigate("/learn", {
+      state: {
+        type: "video",
+        title: title || "Bài học",
+        description,
+        src: url,
+      },
+    });
   };
 
-  const openPdf = (url?: string) => {
+  const openPdf = (url?: string, title?: string, description?: string, estimatedMin?: number) => {
     if (!url) return;
-    setPdfSrc(url);
-    setShowPdfDialog(true);
+    navigate("/learn", {
+      state: {
+        type: "document",
+        title: title || "Tài liệu",
+        description,
+        src: url,
+        estimatedDurationSec: (estimatedMin || 10) * 60,
+      },
+    });
   };
 
   // Lesson player state & handlers
@@ -380,31 +393,25 @@ export default function StudyPlan() {
   };
 
   const openLessonPlayer = (lesson: Lesson) => {
-    setCurrentLesson(lesson);
-    // derive markers: use lesson.quizMarkers if present, else leave empty and generate after metadata loads
-    const markers: number[] = (lesson as any).quizMarkers || [];
-    setVideoMarkers(markers);
-    setMaxAllowedTime(0);
-    setVideoCurrentTime(0);
-    setVideoDuration(0);
-    setSelectedQuizAnswer(null);
-    setCurrentMarkerIndex(null);
-    // choose a playable source: prefer lesson.videoUrl if it's a direct mp4, else fallback to a longer sample mp4
     const sampleMp4 =
       "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4";
     const src =
-      typeof (lesson as any).videoUrl === "string" &&
-      (lesson as any).videoUrl.endsWith(".mp4")
+      typeof (lesson as any).videoUrl === "string" && (lesson as any).videoUrl.endsWith(".mp4")
         ? (lesson as any).videoUrl
         : sampleMp4;
-    setVideoSrc(src);
-    setShowVideoDialog(true);
-    // mark lesson as in-progress if not completed
+    const subject = subjectConfig[lesson.subject as keyof typeof subjectConfig];
+    const descParts = [subject.name, lesson.duration, lesson.day && `${lesson.day} ${lesson.time}`].filter(Boolean);
+    navigate("/learn", {
+      state: {
+        type: "video",
+        title: stripEmojis(lesson.title),
+        description: descParts.join(" • "),
+        src,
+      },
+    });
     if (lesson.status !== "completed") {
       setLessonList((prev) =>
-        prev.map((l) =>
-          l.id === lesson.id ? { ...l, status: "in-progress" } : l,
-        ),
+        prev.map((l) => (l.id === lesson.id ? { ...l, status: "in-progress" } : l)),
       );
     }
   };
@@ -895,10 +902,15 @@ export default function StudyPlan() {
                                 size="sm"
                                 className="ml-2 underline text-sm"
                                 onClick={() =>
-                                  navigate(`/lesson/${lesson.id}/exercise/1`)
+                                  openPdf(
+                                    lesson.pdfUrl,
+                                    stripEmojis(lesson.title),
+                                    `${subject.name} • Tài liệu đính kèm`,
+                                    Number((lesson.duration || "").replace(/[^0-9]/g, "")) || 10,
+                                  )
                                 }
                               >
-                                Làm bài tập
+                                Xem tài liệu
                               </Button>
                             )}
                           </div>
@@ -1106,7 +1118,7 @@ export default function StudyPlan() {
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
             <DialogTitle className="text-2xl font-bold text-primary">
-              🎯 Thêm mục tiêu học tập
+              🎯 Thêm m���c tiêu học tập
             </DialogTitle>
             <DialogDescription>
               Nhập thông tin mục tiêu h����c tập để tạo lộ trình phù hợp

--- a/client/pages/StudyPlan.tsx
+++ b/client/pages/StudyPlan.tsx
@@ -334,7 +334,12 @@ export default function StudyPlan() {
 
   useEffect(() => {}, []);
 
-  const openVideo = (url?: string, title?: string, description?: string, estimatedMin?: number) => {
+  const openVideo = (
+    url?: string,
+    title?: string,
+    description?: string,
+    estimatedMin?: number,
+  ) => {
     if (!url) return;
     navigate("/learn", {
       state: {
@@ -346,7 +351,12 @@ export default function StudyPlan() {
     });
   };
 
-  const openPdf = (url?: string, title?: string, description?: string, estimatedMin?: number) => {
+  const openPdf = (
+    url?: string,
+    title?: string,
+    description?: string,
+    estimatedMin?: number,
+  ) => {
     if (!url) return;
     navigate("/learn", {
       state: {
@@ -396,16 +406,24 @@ export default function StudyPlan() {
     const sampleMp4 =
       "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4";
     const src =
-      typeof (lesson as any).videoUrl === "string" && (lesson as any).videoUrl.endsWith(".mp4")
+      typeof (lesson as any).videoUrl === "string" &&
+      (lesson as any).videoUrl.endsWith(".mp4")
         ? (lesson as any).videoUrl
         : sampleMp4;
     const subject = subjectConfig[lesson.subject as keyof typeof subjectConfig];
-    const descParts = [subject.name, lesson.duration, lesson.day && `${lesson.day} ${lesson.time}`].filter(Boolean);
+    const descParts = [
+      subject.name,
+      lesson.duration,
+      lesson.day && `${lesson.day} ${lesson.time}`,
+    ].filter(Boolean);
     const conceptTags: string[] = [];
     const lowerTitle = stripEmojis(lesson.title).toLowerCase();
     if (/cộng/.test(lowerTitle)) conceptTags.push("addition");
     if (/trừ/.test(lowerTitle)) conceptTags.push("subtraction");
-    if (subject.name.toLowerCase().includes("toán") && conceptTags.length === 0) {
+    if (
+      subject.name.toLowerCase().includes("toán") &&
+      conceptTags.length === 0
+    ) {
       conceptTags.push("addition");
     }
     navigate("/learn", {
@@ -421,7 +439,9 @@ export default function StudyPlan() {
     });
     if (lesson.status !== "completed") {
       setLessonList((prev) =>
-        prev.map((l) => (l.id === lesson.id ? { ...l, status: "in-progress" } : l)),
+        prev.map((l) =>
+          l.id === lesson.id ? { ...l, status: "in-progress" } : l,
+        ),
       );
     }
   };
@@ -916,7 +936,12 @@ export default function StudyPlan() {
                                     lesson.pdfUrl,
                                     stripEmojis(lesson.title),
                                     `${subject.name} • Tài liệu đính kèm`,
-                                    Number((lesson.duration || "").replace(/[^0-9]/g, "")) || 10,
+                                    Number(
+                                      (lesson.duration || "").replace(
+                                        /[^0-9]/g,
+                                        "",
+                                      ),
+                                    ) || 10,
                                   )
                                 }
                               >

--- a/client/pages/StudyPlan.tsx
+++ b/client/pages/StudyPlan.tsx
@@ -401,12 +401,22 @@ export default function StudyPlan() {
         : sampleMp4;
     const subject = subjectConfig[lesson.subject as keyof typeof subjectConfig];
     const descParts = [subject.name, lesson.duration, lesson.day && `${lesson.day} ${lesson.time}`].filter(Boolean);
+    const conceptTags: string[] = [];
+    const lowerTitle = stripEmojis(lesson.title).toLowerCase();
+    if (/cộng/.test(lowerTitle)) conceptTags.push("addition");
+    if (/trừ/.test(lowerTitle)) conceptTags.push("subtraction");
+    if (subject.name.toLowerCase().includes("toán") && conceptTags.length === 0) {
+      conceptTags.push("addition");
+    }
     navigate("/learn", {
       state: {
         type: "video",
         title: stripEmojis(lesson.title),
         description: descParts.join(" • "),
         src,
+        lessonId: String(lesson.id),
+        conceptTags,
+        promptTimesSec: [60, 120, 180],
       },
     });
     if (lesson.status !== "completed") {
@@ -1118,7 +1128,7 @@ export default function StudyPlan() {
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
             <DialogTitle className="text-2xl font-bold text-primary">
-              🎯 Thêm m���c tiêu học tập
+              🎯 Thêm mục tiêu học tập
             </DialogTitle>
             <DialogDescription>
               Nhập thông tin mục tiêu h����c tập để tạo lộ trình phù hợp


### PR DESCRIPTION
## Purpose
Based on the conversation history, users were experiencing runtime errors and requested improvements to the lesson viewing experience. The user specifically asked to focus on enhancing the lesson viewing page rather than popup functionality, indicating a need for a better learning interface.

## Code changes
- **New Learn page**: Created `client/pages/Learn.tsx` with comprehensive video/document viewing capabilities
- **Enhanced navigation**: Added `/learn` route to App.tsx routing configuration  
- **Improved study flow**: Modified StudyPlan.tsx to navigate to the new Learn page instead of opening modal dialogs
- **Better user experience**: Updated DashboardHome.tsx to navigate to study plan when starting courses

### Key features added to Learn page:
- Video and document viewing with progress tracking
- Interactive concept hints and visual aids
- Reflection prompts and note-taking functionality
- Quick comprehension quizzes
- Motivational progress milestones
- Zoom controls for documents
- Auto-save progress to server
- Break reminders for extended study sessions

### Navigation improvements:
- Course cards now navigate to `/study-plan` when clicked
- Lesson viewing redirects to dedicated Learn page
- PDF and video content opens in full-featured Learn interface instead of basic modalsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a8d9cdafdd1b4f34b3453e16dd80e392/orbit-oasis)

👀 [Preview Link](https://a8d9cdafdd1b4f34b3453e16dd80e392-orbit-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a8d9cdafdd1b4f34b3453e16dd80e392</projectId>-->
<!--<branchName>orbit-oasis</branchName>-->